### PR TITLE
Removed modifiers on MouseEvent, it's defined on Event

### DIFF
--- a/paper.d.ts
+++ b/paper.d.ts
@@ -4080,11 +4080,6 @@ declare module 'paper' {
         timeStamp(): number;
 
         /**
-         * The current state of the keyboard modifiers.
-         */
-        modifiers(): any;
-
-        /**
          * Cancels the event if it is cancelable, without stopping further
          * propagation of the event.
          */


### PR DESCRIPTION
Sorry that I missed this. It throws an error when I try to transpile my project.