### PR TITLE
Added hex string option to Color constructor

### DIFF
--- a/paper.d.ts
+++ b/paper.d.ts
@@ -3512,6 +3512,12 @@ declare module 'paper' {
          * @param highlight [optional] -
          */
         constructor(color: Gradient, origin: Point, destination: Point, highlight?: Point);
+        
+        /**
+         * Creates a RGB Color object.
+         * @param hex - the RGB color in hex, i.e. #000000
+         */
+        constructor(hex: string);
 
         /**
          * The type of the color as a string.


### PR DESCRIPTION
Passing a string into Color worked prior to Typescript 2.4