### PR TITLE
Raster setImageData incorrectly named

### DIFF
--- a/paper.d.ts
+++ b/paper.d.ts
@@ -2086,7 +2086,7 @@ declare module 'paper' {
          * @param data
          * @param point
          */
-        getImageData(data: ImageData, point: Point): void;
+        setImageData(data: ImageData, point: Point): void;
 
     }
     /**


### PR DESCRIPTION
Raster setImageData was incorrectly named to getImageData. DefinitelyTyped currently uses the correct name.